### PR TITLE
Add feature id temp support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('README.md', 'r', encoding='utf-8') as f:
 
 setup(
     name='vt2pbf',
-    version='0.1.2',
+    version='0.1.3',
     description='Python library for encoding mapbox vector tiles into tile_pbf',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/vt2pbf/service/layer.py
+++ b/vt2pbf/service/layer.py
@@ -22,7 +22,9 @@ class Layer:
 
     def add_feature(self, feature_info: dict, feature_id: int = None):
         self._validate_feature(feature_info)
-        feature = Feature(layer=self, feature_type=feature_info['type'], feature_id=feature_id)
+        feature = Feature(
+            layer=self, feature_type=feature_info['type'], feature_id=feature_id or feature_info.get('id')
+        )
         feature.add_tags(tags=feature_info['tags'])
         feature.add_geometry(geometry=feature_info['geometry'])
 


### PR DESCRIPTION
vt2pbf (is mainfuly port of [JS vt-pbf](https://github.com/mapbox/vt-pbf) which is has not same functionality) used a [geojson2vt](https://github.com/geometalab/geojson2vt) object as input.
In main function `vt2pbf` we are taking features as `vector_tile['features']`

This future object has next fields by default: `'geometry', 'type', 'tags'` which are used to endoce tile into pbf format.
If you need to add an feature_id to your encoded tile you can add parameter `'id'` into `vector_tile['features']` object before calling main `vt2pbf` and encoded tiles will have provided feature id